### PR TITLE
Dev/improvements

### DIFF
--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -81,13 +81,21 @@ class LogFilter
 
     # Atom folds the line under the selected row
     # and the first line doesn't really fold
-    actualStartLine = start-1
+    actualStartLine = start
     actualStartColumn = 0
-    if actualStartLine <= 0
-      actualStartLine = 0
+    foldPositionConfig = atom.config.get('language-log.foldPosition')
+    if 'end-of-line' == foldPositionConfig
+      actualStartLine = start-1
       actualStartColumn = 0
-    else
-      actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+      if actualStartLine <= 0
+        actualStartLine = 0
+        actualStartColumn = 0
+      else
+        actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+    else if 'between-lines' == foldPositionConfig
+      actualStartLine = start
+      actualStartColumn = 0
+
     @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -79,8 +79,6 @@ class LogFilter
   foldLineRange: (start, end) ->
     return unless start? and end?
 
-    # Atom folds the line under the selected row
-    # and the first line doesn't really fold
     actualStartLine = start
     actualStartColumn = 0
     foldPositionConfig = atom.config.get('language-log.foldPosition')

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -79,10 +79,14 @@ class LogFilter
   foldLineRange: (start, end) ->
     return unless start? and end?
 
+    # By default,as fallback case, we keep the safest possibility,
+    # the fold start at the first character of the first line to fold
     actualStartLine = start
     actualStartColumn = 0
     foldPositionConfig = atom.config.get('language-log.foldPosition')
     if 'end-of-line' == foldPositionConfig
+      # We fold at the end of the last filtered line
+      # except if the first line to fold is the first line in the text editor
       actualStartLine = start-1
       actualStartColumn = 0
       if actualStartLine <= 0
@@ -91,9 +95,11 @@ class LogFilter
       else
         actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
     else if 'between-lines' == foldPositionConfig
+      # The fold start at the first character of the first line to fold
       actualStartLine = start
       actualStartColumn = 0
 
+    # We fold until the end of the last line to fold
     @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -81,7 +81,14 @@ class LogFilter
 
     # Atom folds the line under the selected row
     # and the first line doesn't really fold
-    @textEditor.setSelectedBufferRange([[start - 1, 0], [end, 0]])
+    actualStartLine = start-1
+    actualStartColumn = 0
+    if actualStartLine <= 0
+      actualStartLine = 0
+      actualStartColumn = 0
+    else
+      actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+    @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 
   shouldFilterScopes: (tokens, filterScopes) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,14 @@ module.exports = LanguageLog =
     tail:
       type: 'boolean'
       default: false
+    foldPosition:
+      type: 'string'
+      default: 'end-of-line'
+      description: 'Determine if the fold appears at the end of a filtered line or between two filtered lines.'
+      enum: [
+        {value: 'end-of-line', description: 'Fold block at the end of filtered lines.'}
+        {value: 'between-lines', description: 'Fold block between two filtered lines.'}
+      ]
 
   activate: (state) ->
     @disposables = new CompositeDisposable


### PR DESCRIPTION
- Fix folding by not folding filtered lines
- Add setting to fold at the end of the line or between lines

I was trying to use the package for my Objective-C log, expected to get something as useful as the filter provided by AndroidStudio for Android logs. I got several issues to get what I wanted. First I wanted to fix the behaviour of folding to fit what I expected (and I guess should be).

I'm also currently working on other improvements to fit my requirements (option to display multi-lines log entry after, option to display some lines before and after the filtered lines).