### PR TITLE
Dev/integration check

### DIFF
--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -81,13 +81,21 @@ class LogFilter
 
     # Atom folds the line under the selected row
     # and the first line doesn't really fold
-    actualStartLine = start-1
+    actualStartLine = start
     actualStartColumn = 0
-    if actualStartLine <= 0
-      actualStartLine = 0
+    foldPositionConfig = atom.config.get('language-log.foldPosition')
+    if 'end-of-line' == foldPositionConfig
+      actualStartLine = start-1
       actualStartColumn = 0
-    else
-      actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+      if actualStartLine <= 0
+        actualStartLine = 0
+        actualStartColumn = 0
+      else
+        actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+    else if 'between-lines' == foldPositionConfig
+      actualStartLine = start
+      actualStartColumn = 0
+
     @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -79,8 +79,6 @@ class LogFilter
   foldLineRange: (start, end) ->
     return unless start? and end?
 
-    # Atom folds the line under the selected row
-    # and the first line doesn't really fold
     actualStartLine = start
     actualStartColumn = 0
     foldPositionConfig = atom.config.get('language-log.foldPosition')

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -15,6 +15,7 @@ class LogFilter
       text: []
       levels: []
       times: []
+      linesWithTimestamp: []
 
   onDidFinishFilter: (cb) -> @emitter.on 'did-finish-filter', cb
 
@@ -40,8 +41,37 @@ class LogFilter
 
     return unless regex
 
-    @results.text = for line, i in buffer.getLines()
-      if regex.test(line) then else i
+    if atom.config.get('language-log.useMultiLinesLogEntrySupport')
+      # We build a list of log entries, instead of lines,
+      # to be able to parse an entry at once and as a whole
+      logEntriesArray = []
+      # To stick to the original way the folding is done,
+      # because now we are working with several lines at a time,
+      # we need to fill for each recognized log entry a list of lines instead of a single one.
+      linesIndexes = []
+      @performLinesWithTimestampFilter()
+      for line, i in @results.linesWithTimestamp
+        start = line
+        end = line
+        if i + 1 < @results.linesWithTimestamp.length
+          start = line
+          end = @results.linesWithTimestamp[i+1]-1
+        logEntriesArray.push(buffer.getTextInRange([[start, 0], [end, @textEditor.getBuffer().lineLengthForRow(end)]]))
+        indexesForLines = []
+        for lineNumber in [start..end]
+          indexesForLines.push(lineNumber)
+        linesIndexes.push(indexesForLines)
+      lineToDisplayIndexes = []
+      console.log (logEntriesArray)
+      console.log (linesIndexes)
+      for logLine, i in logEntriesArray
+        console.log(regex.test(logLine)+" : ["+i+"]"+logLine)
+        if regex.test(logLine) then else lineToDisplayIndexes = lineToDisplayIndexes.concat(linesIndexes[i])
+      @results.text = lineToDisplayIndexes
+    else
+      @results.text = for line, i in buffer.getLines()
+        if regex.test(line) then else i
+    console.log (@results)
     @filterLines()
 
   performLevelFilter: (scopes) ->
@@ -54,6 +84,13 @@ class LogFilter
       tokens = grammar.tokenizeLine(line)
       if @shouldFilterScopes(tokens, scopes) then i else
     @filterLines()
+
+  # XXX: Based on experimental code for log line timestamp extraction
+  performLinesWithTimestampFilter: ->
+    return unless buffer = @textEditor.getBuffer()
+
+    @results.linesWithTimestamp = for line, i in buffer.getLines()
+      if !timestamp = @getLineTimestamp(i) then else i
 
   # XXX: Experimental log line timestamp extraction
   #      Not used in production
@@ -125,7 +162,12 @@ class LogFilter
   getLineTimestamp: (lineNumber) ->
     for pos in [0..30] by 10
       point = new Point(lineNumber, pos)
-      range = @textEditor.displayBuffer.bufferRangeForScopeAtPosition('timestamp', point)
+      # DEPRECATED
+      # range = @textEditor.displayBuffer.bufferRangeForScopeAtPosition('timestamp', point)
+      # REPLACEMENT
+      @textEditor.setCursorBufferPosition(point)
+      range = @textEditor.bufferRangeForScopeAtCursor('timestamp')
+
       if range and timestamp = @textEditor.getTextInRange(range)
         return @parseTimestamp(timestamp)
 

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -144,13 +144,21 @@ class LogFilter
 
   getRegexFromText: (text) ->
     try
+      regexpPattern = text
+      regexpFlags = ''
       if text[0] is '!'
-        new RegExp("^((?!#{text.substr(1)}).)*$", 'i')
+        regexpPattern = "^((?!#{text.substr(1)}).)*$"
+      if atom.config.get('language-log.caseInsensitive')
+        regexpFlags += 'i'
+
+      if regexpFlags
+        return new RegExp(regexpPattern, regexpFlags)
       else
-        new RegExp(text, 'i')
+        return new RegExp(regexpPattern)
+
     catch error
       atom.notifications.addWarning('Log Language', detail: 'Invalid filter regex')
-      false
+      return false
 
   removeFilter: ->
     @textEditor.unfoldAll()

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -79,10 +79,14 @@ class LogFilter
   foldLineRange: (start, end) ->
     return unless start? and end?
 
+    # By default,as fallback case, we keep the safest possibility,
+    # the fold start at the first character of the first line to fold
     actualStartLine = start
     actualStartColumn = 0
     foldPositionConfig = atom.config.get('language-log.foldPosition')
     if 'end-of-line' == foldPositionConfig
+      # We fold at the end of the last filtered line
+      # except if the first line to fold is the first line in the text editor
       actualStartLine = start-1
       actualStartColumn = 0
       if actualStartLine <= 0
@@ -91,9 +95,11 @@ class LogFilter
       else
         actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
     else if 'between-lines' == foldPositionConfig
+      # The fold start at the first character of the first line to fold
       actualStartLine = start
       actualStartColumn = 0
 
+    # We fold until the end of the last line to fold
     @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -62,16 +62,12 @@ class LogFilter
           indexesForLines.push(lineNumber)
         linesIndexes.push(indexesForLines)
       lineToDisplayIndexes = []
-      console.log (logEntriesArray)
-      console.log (linesIndexes)
       for logLine, i in logEntriesArray
-        console.log(regex.test(logLine)+" : ["+i+"]"+logLine)
         if regex.test(logLine) then else lineToDisplayIndexes = lineToDisplayIndexes.concat(linesIndexes[i])
       @results.text = lineToDisplayIndexes
     else
       @results.text = for line, i in buffer.getLines()
         if regex.test(line) then else i
-    console.log (@results)
     @filterLines()
 
   performLevelFilter: (scopes) ->

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -68,6 +68,25 @@ class LogFilter
     else
       @results.text = for line, i in buffer.getLines()
         if regex.test(line) then else i
+
+    if 0 < @results.text.length
+      resultsHeadLength = atom.config.get('language-log.precedingFilteredExpansion')
+      if 0 < resultsHeadLength
+        resultsWithHead = []
+        for lineNumber, lineIndex in @results.text
+          if ( lineIndex + resultsHeadLength < @results.text.length and lineNumber + resultsHeadLength >= @results.text[lineIndex + resultsHeadLength] ) or ( lineIndex + resultsHeadLength >= @results.text.length and 0 == ( @results.text.length - lineIndex ) - ( @textEditor.getLineCount() - lineNumber ) )
+            resultsWithHead.push(lineNumber)
+        @results.text = resultsWithHead
+      resultsTailLength = atom.config.get('language-log.followingFilteredExpansion')
+      if 0 < resultsTailLength
+        resultsWithTail = []
+        @results.text.reverse()
+        for lineNumber, lineIndex in @results.text
+          if ( lineIndex + resultsTailLength < @results.text.length and lineNumber - resultsTailLength <= @results.text[lineIndex + resultsTailLength] ) or ( lineIndex + resultsTailLength >= @results.text.length and 0 == ( @results.text.length - lineIndex ) - ( lineNumber + 1 ) )
+            resultsWithTail.push(lineNumber)
+        resultsWithTail.reverse()
+        @results.text = resultsWithTail
+
     @filterLines()
 
   performLevelFilter: (scopes) ->

--- a/lib/log-filter.coffee
+++ b/lib/log-filter.coffee
@@ -81,7 +81,14 @@ class LogFilter
 
     # Atom folds the line under the selected row
     # and the first line doesn't really fold
-    @textEditor.setSelectedBufferRange([[start - 1, 0], [end, 0]])
+    actualStartLine = start-1
+    actualStartColumn = 0
+    if actualStartLine <= 0
+      actualStartLine = 0
+      actualStartColumn = 0
+    else
+      actualStartColumn = @textEditor.getBuffer().lineLengthForRow(actualStartLine)
+    @textEditor.setSelectedBufferRange([[actualStartLine, actualStartColumn], [end, @textEditor.getBuffer().lineLengthForRow(end)]])
     @textEditor.getSelections()[0].fold()
 
   shouldFilterScopes: (tokens, filterScopes) ->

--- a/lib/log-view.coffee
+++ b/lib/log-view.coffee
@@ -38,6 +38,8 @@ class LogView extends View
             @button outlet: 'filterButton', class: 'btn', 'Filter'
           @div class: 'btn-group', =>
             @button outlet: 'tailButton', class: 'btn btn-icon icon-arrow-down'
+          @div class: 'btn-group', =>
+            @button outlet: 'caseSensistiveButton', class: 'btn', 'Aa'
           @div class: 'btn-group btn-group-level', =>
             @button outlet: 'levelVerboseButton', class: 'btn log-verbose', 'V'
             @button outlet: 'levelInfoButton', class: 'btn log-info', 'I'
@@ -69,6 +71,8 @@ class LogView extends View
       title: "Filter Log Lines"
     @disposables.add atom.tooltips.add @tailButton,
       title: "Tail On File Changes"
+    @disposables.add atom.tooltips.add @caseSensistiveButton,
+      title: "Toggle case sensitivity"
     @disposables.add atom.tooltips.add @levelVerboseButton,
       title: "Toggle Verbose Level"
     @disposables.add atom.tooltips.add @levelInfoButton,
@@ -92,6 +96,7 @@ class LogView extends View
 
     @filterButton.on 'click', => @confirm()
     @tailButton.on 'click', => @toggleTail()
+    @caseSensistiveButton.on 'click', => @toggleCaseSensitivity()
     @levelVerboseButton.on 'click', => @toggleButton('verbose')
     @levelInfoButton.on 'click', => @toggleButton('info')
     @levelDebugButton.on 'click', => @toggleButton('debug')
@@ -116,6 +121,11 @@ class LogView extends View
     @updateButtons()
     @tail()
 
+  toggleCaseSensitivity: ->
+    atom.config.set('language-log.caseInsensitive', !atom.config.get('language-log.caseInsensitive'))
+    @updateButtons()
+    @confirm()
+
   toggleButton: (level) ->
     @settings[level] = if @settings[level] then false else true
     @updateButtons()
@@ -123,6 +133,7 @@ class LogView extends View
 
   updateButtons: ->
     @tailButton.toggleClass('selected', atom.config.get('language-log.tail'))
+    @caseSensistiveButton.toggleClass('selected', !atom.config.get('language-log.caseInsensitive'))
     @levelVerboseButton.toggleClass('selected', @settings.verbose)
     @levelInfoButton.toggleClass('selected', @settings.info)
     @levelDebugButton.toggleClass('selected', @settings.debug)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,6 +10,14 @@ module.exports = LanguageLog =
     tail:
       type: 'boolean'
       default: false
+    foldPosition:
+      type: 'string'
+      default: 'end-of-line'
+      description: 'Determine if the fold appears at the end of a filtered line or between two filtered lines.'
+      enum: [
+        {value: 'end-of-line', description: 'Fold block at the end of filtered lines.'}
+        {value: 'between-lines', description: 'Fold block between two filtered lines.'}
+      ]
 
   activate: (state) ->
     @disposables = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -23,6 +23,9 @@ module.exports = LanguageLog =
       title: 'Use multi-lines Log entry support'
       default: false
       description: 'Let displayed the whole log entry after filter instead of only the line even if the log entry has several lines.'
+    caseInsensitive:
+      type: 'boolean'
+      default: true
 
   activate: (state) ->
     @disposables = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,6 +26,16 @@ module.exports = LanguageLog =
     caseInsensitive:
       type: 'boolean'
       default: true
+    precedingFilteredExpansion:
+      type: 'integer'
+      title: 'Number of preceding lines displayed'
+      default: 0
+      minimum: 0
+    followingFilteredExpansion:
+      type: 'integer'
+      title: 'Number of following lines displayed'
+      default: 0
+      minimum: 0
 
   activate: (state) ->
     @disposables = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -18,6 +18,11 @@ module.exports = LanguageLog =
         {value: 'end-of-line', description: 'Fold block at the end of filtered lines.'}
         {value: 'between-lines', description: 'Fold block between two filtered lines.'}
       ]
+    useMultiLinesLogEntrySupport:
+      type: 'boolean'
+      title: 'Use multi-lines Log entry support'
+      default: false
+      description: 'Let displayed the whole log entry after filter instead of only the line even if the log entry has several lines.'
 
   activate: (state) ->
     @disposables = new CompositeDisposable


### PR DESCRIPTION
- Fix folding by not folding filtered lines
- Add setting to fold at the end of the line or between lines
- Add setting to display multi-lines log entry entirely after filter
- Fix travis build failure due to use of deprecated API
- Add setting to toggle case sensitivity in filter regexp
- Add toggle case sensitivity button in Filter-bar
- Add setting to display some lines before and after the filtered lines

I was trying to use the package for my Objective-C log, expected to get something as useful as the filter provided by AndroidStudio for Android logs. I got several issues to get what I wanted. First I wanted to fix the behaviour of folding to fit what I expected (and I guess should be).

PS : If the merge request contains too many things/features and you prefer to integrate them in an other way, I have one branch per feature so please, feel free to ask.
