### PR TITLE
Add command to toggle the log panel

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,6 +40,8 @@ module.exports = LanguageLog =
 
     @disposables.add atom.workspace.observeActivePaneItem (item) =>
       @itemUpdate(item)
+      
+    atom.commands.add 'atom-workspace', 'log:toggle-log-panel', => @toggleLogPanel()
 
   deactivate: ->
     @disposables.dispose()
@@ -52,11 +54,10 @@ module.exports = LanguageLog =
 
     @grammarDisposable.add item.observeGrammar? (grammar) =>
       @removeLogPanel()
-      @addLogPanel(item) if grammar.name is 'Log'
+      if grammar.name is 'Log' && atom.config.get 'language-log.showFilterBar'
+        @addLogPanel(item)
 
   addLogPanel: (textEditor) ->
-    return unless atom.config.get 'language-log.showFilterBar'
-
     # Create new log view if opened log differs from previous
     unless @logView?.textEditor is textEditor
       LogView ?= require './log-view'
@@ -67,3 +68,9 @@ module.exports = LanguageLog =
 
   removeLogPanel: ->
     @logPanel?.destroy()
+
+  toggleLogPanel: ->
+    if @logPanel?
+      @removeLogPanel()
+    else
+      @addLogPanel(atom.workspace.getActiveTextEditor())

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -68,6 +68,7 @@ module.exports = LanguageLog =
 
   removeLogPanel: ->
     @logPanel?.destroy()
+    @logPanel = null
 
   toggleLogPanel: ->
     if @logPanel?

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -72,6 +72,7 @@ describe "Log", ->
         expect(logModule.logView.settings.verbose).toEqual false
 
     it "toggles on grammar change from log", ->
+      atom.config.set 'language-log.showFilterBar', true
       waitsForPromise ->
         atom.packages.activatePackage('language-text')
         atom.workspace.open 'android.log'

--- a/spec/main-spec.coffee
+++ b/spec/main-spec.coffee
@@ -114,3 +114,24 @@ describe "Log", ->
         expect(workspaceElement.querySelector('.log-view')).toExist()
         atom.workspace.getActivePane().activatePreviousItem()
         expect(workspaceElement.querySelector('.log-view')).not.toExist()
+
+  describe "toggle-log-panel", ->
+    it "opens the log panel if it is disabled", ->
+      waitsForPromise ->
+        atom.workspace.open '../log-spec.coffee'
+      runs ->
+        expect(workspaceElement.querySelector('.log-panel')).not.toExist()
+
+        atom.commands.dispatch(atom.views.getView(atom.workspace), 'log:toggle-log-panel')
+
+        expect(workspaceElement.querySelector('.log-panel')).toExist()
+
+    it "closes the log panel if it is enabled", ->
+      waitsForPromise ->
+        atom.workspace.open 'android.log'
+      runs ->
+        expect(workspaceElement.querySelector('.log-panel')).toExist()
+
+        atom.commands.dispatch(atom.views.getView(atom.workspace), 'log:toggle-log-panel')
+
+        expect(workspaceElement.querySelector('.log-panel')).not.toExist()


### PR DESCRIPTION
This adds a new command `log:toggle-log-panel` which will add (or remove) the log panel on-demand, enabling the tail and filtering features for files not covered by the built-in grammar.