### PR TITLE
Add menu item and keymap to toggle filter

### DIFF
--- a/keymaps/language-log.json
+++ b/keymaps/language-log.json
@@ -1,0 +1,5 @@
+{
+  "atom-workspace": {
+    "ctrl-alt-l": "log:toggle-log-panel"
+  }
+}

--- a/menus/language-log.json
+++ b/menus/language-log.json
@@ -1,0 +1,18 @@
+{
+  "menu": [
+    {
+      "label": "Packages",
+      "submenu": [
+        {
+          "label": "Language-log",
+          "submenu": [
+            {
+              "label": "Toggle filter",
+              "command": "log:toggle-log-panel"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Easier to use the filter function by having a menu item for
toggling it.
Also add a standard keymap for the toggle, ctrl-alt-l.
Toggling allows to use the filter function on files that are not .log.
Having a menu item allows new users to know the option is there.